### PR TITLE
main runs runAgda with stub Backend

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -8,8 +8,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: haskell-actions/setup@v2
         with:
-          ghc-version: '9.8'
-          cabal-version: '3.8'
+          ghc-version: '9.8.1'
+          cabal-version: '3.10.1.0'
 
       - name: Build
         run: cabal build all

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -18,4 +18,4 @@ jobs:
         run: cabal test all
       
       - name: Run tests
-        run: cabal run agda2scala
+        run: cabal run -- agda2scala ./test/Hello.agda

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: haskell-actions/setup@v2
         with:
           ghc-version: '9.8'
-          cabal-version: '3.0'
+          cabal-version: '3.10'
 
       - name: Build
         run: cabal build all

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: haskell-actions/setup@v2
         with:
           ghc-version: '9.8'
-          cabal-version: '3.10'
+          cabal-version: '3.8'
 
       - name: Build
         run: cabal build all

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: haskell-actions/setup@v2
         with:
-          ghc-version: '9.6'
+          ghc-version: '9.8'
           cabal-version: '3.0'
 
       - name: Build

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 dist-newstyle
+*.iml
+.idea

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ cabal build all
 * Run
 
 ```sh
-cabal run agda2scala
+cabal run -- agda2scala ./test/Hello.agda
 ```
 
 * Run tests

--- a/agda2scala.cabal
+++ b/agda2scala.cabal
@@ -1,4 +1,4 @@
-cabal-version:      3.10
+cabal-version:      3.8
 -- The cabal-version field refers to the version of the .cabal specification,
 -- and can be different from the cabal-install (the tool) version and the
 -- Cabal (the library) version you are using. As such, the Cabal (the library)

--- a/agda2scala.cabal
+++ b/agda2scala.cabal
@@ -23,7 +23,7 @@ name:               agda2scala
 version:            0.1.0.0
 
 -- A short (one-line) description of the package.
--- synopsis:
+synopsis:           Agda backend for Scala
 
 -- A longer description of the package.
 -- description:
@@ -91,8 +91,8 @@ executable agda2scala
 
     -- Other library packages from which modules are imported.
     build-depends:
-        base ^>=4.18.0.0,
-        agda2scala
+        base ^>=4.18.0.0
+        , Agda <= 2.6.4
 
     -- Directories containing source files.
     hs-source-dirs:   app
@@ -124,5 +124,5 @@ test-suite agda2scala-test
 
     -- Test dependencies.
     build-depends:
-        base ^>=4.18.0.0,
-        agda2scala
+        base ^>=4.18.0.0
+        , agda2scala

--- a/agda2scala.cabal
+++ b/agda2scala.cabal
@@ -1,4 +1,4 @@
-cabal-version:      3.0
+cabal-version:      3.10
 -- The cabal-version field refers to the version of the .cabal specification,
 -- and can be different from the cabal-install (the tool) version and the
 -- Cabal (the library) version you are using. As such, the Cabal (the library)

--- a/agda2scala.cabal
+++ b/agda2scala.cabal
@@ -92,6 +92,7 @@ executable agda2scala
     -- Other library packages from which modules are imported.
     build-depends:
         base ^>=4.18.0.0
+        , agda2scala
         , Agda <= 2.6.4
 
     -- Directories containing source files.

--- a/agda2scala.cabal
+++ b/agda2scala.cabal
@@ -68,7 +68,7 @@ library
     -- other-extensions:
 
     -- Other library packages from which modules are imported.
-    build-depends:    base ^>=4.18.0.0
+    build-depends:    base ^>=4.19.0.0
 
     -- Directories containing source files.
     hs-source-dirs:   src
@@ -91,7 +91,7 @@ executable agda2scala
 
     -- Other library packages from which modules are imported.
     build-depends:
-        base ^>=4.18.0.0
+        base ^>=4.19.0.0
         , agda2scala
         , Agda <= 2.6.4
 
@@ -125,5 +125,5 @@ test-suite agda2scala-test
 
     -- Test dependencies.
     build-depends:
-        base ^>=4.18.0.0
+        base ^>=4.19.0.0
         , agda2scala

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,8 +1,27 @@
 module Main where
 
-import qualified MyLib (someFunc)
+import Agda.Compiler.Backend
+import Agda.Main ( runAgda )
 
 main :: IO ()
-main = do
-  putStrLn "Hello, Haskell!"
-  MyLib.someFunc
+main = runAgda [backend]
+
+backend :: Backend
+backend = Backend scalaBackend
+
+-- Backend' opts env menv0 mod0 def0
+scalaBackend :: Backend' () () () () ()
+scalaBackend = Backend'
+  { backendName           = "agda2scala"
+  , backendVersion        = Nothing
+  , options               = ()
+  , commandLineFlags      = []
+  , isEnabled             = \ _ -> True
+  , preCompile            = \ _ -> return ()
+  , postCompile           = \ _ _ _ -> return ()
+  , preModule             = \ _ _ _ _ -> return $ Recompile ()
+  , postModule            = \ _ _ _ _ _ -> return ()
+  , compileDef            = \ _ _ _ _ -> return ()
+  , scopeCheckingSuffices = False
+  , mayEraseType          = \ _ -> return True
+  }

--- a/test/Hello.agda
+++ b/test/Hello.agda
@@ -1,0 +1,9 @@
+module Hello where
+
+data Bool : Set where
+  true : Bool
+  false : Bool
+
+not : Bool -> Bool
+not true  = false
+not false = true

--- a/test/Hello.agda
+++ b/test/Hello.agda
@@ -1,4 +1,4 @@
-module Hello where
+module test.Hello where
 
 data Bool : Set where
   true : Bool


### PR DESCRIPTION
* Add dependency to [Agda](https://hackage.haskell.org/package/Agda/docs/Agda-Compiler-Backend.html)
* create dummy implementation of Backend
* version of cabal fixed at `3.10.1.0` as CI by default choose
```text
Resolved cabal 3.10 to 3.10.2.0
```
and breaks with
```text
Adding /home/runner/.cabal/bin to PATH
  /home/runner/.ghcup/bin/cabal update
  Errors encountered when parsing cabal file ./agda2scala.cabal:
  
  agda2scala.cabal:0:0: error:
  Unsupported cabal-version 3.10. See https://github.com/haskell/cabal/issues/4899.
 ```